### PR TITLE
[Palisade] Disable graphical output of ROOT

### DIFF
--- a/PostProcessing/python/Palisade/Processors/_base.py
+++ b/PostProcessing/python/Palisade/Processors/_base.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import six
 import warnings
+import ROOT
 
 from copy import deepcopy
 from tqdm import tqdm
@@ -202,6 +203,10 @@ class _ProcessorBase(object):
             show_progress : `bool`
                 if :py:const:`True`, a progress bar will be shown
         """
+
+        # Disable graphical output of ROOT
+        ROOT.gROOT.SetBatch(True)
+
         # -- run over cross product of expansion
 
         # go through each configured action


### PR DESCRIPTION
Disable graphical output of ROOT during Palisade execution per default. This affects the AnalyzeProcessor and PlotProcessor, since the base class is changed.