### PR TITLE
Enable usage of register_local() for PlotProcessor()

### DIFF
--- a/PostProcessing/python/Palisade/Processors/_plot.py
+++ b/PostProcessing/python/Palisade/Processors/_plot.py
@@ -308,7 +308,7 @@ class PlotProcessor(_ProcessorBase):
         _mplrc()
 
         # register expressions as locals for lookup by the input controller's `get` call
-        self._input_controller.register_local('expressions', [_subplot_cfg['expression'] for _subplot_cfg in config['subplots']])
+        self._input_controller.register_local('expressions', [_subplot_cfg['expression'] for _subplot_cfg in config['subplots']], override=True)
 
         _filename = os.path.join(self._output_folder, config['filename'])
 
@@ -775,7 +775,7 @@ class PlotProcessor(_ProcessorBase):
                 yaml.dump(_config_for_dump, _yaml_file)
 
         # de-register all the locals after a plot is done
-        self._input_controller.clear_locals()
+        # self._input_controller.clear_locals()
 
 
     # -- register action slots

--- a/PostProcessing/python/Palisade/_input.py
+++ b/PostProcessing/python/Palisade/_input.py
@@ -1207,7 +1207,7 @@ class InputROOT(object):
                 _reqs.append(dict(object_spec=_obj_spec, force_rerequest=False, **other_request_params))
         self.request(_reqs)
 
-    def register_local(self, name, value):
+    def register_local(self, name, value, override=False):
         """
         Register a local variable to be used when evaluating an expression using
         :py:meth:`~DijetAnalysis.PostProcessing.Palisade.InputROOT.get_expr`
@@ -1219,11 +1219,12 @@ class InputROOT(object):
             value :
                 any Python object to be made accessible in expressions under :py:const:`name`.
         """
-        try:
-            assert name not in self._locals
-        except AssertionError as e:
-            print("[ERROR] Cannot register local '{}' with value {}! It already exists and is: {}".format(name, value, self._locals[name]))
-            raise e
+        if not override:
+            try:
+                assert name not in self._locals
+            except AssertionError as e:
+                print("[ERROR] Cannot register local '{}' with value {}! It already exists and is: {}".format(name, value, self._locals[name]))
+                raise e
         self._locals[name] = value
 
     def clear_locals(self):


### PR DESCRIPTION
`input_controller.register_local()` now allows to overwrite existing entries by using flag `override=True`, default is set to `False` for backwards-compatibility.