### PR TITLE
Sorted output

### DIFF
--- a/PostProcessing/python/Lumberjack/_postprocessor.py
+++ b/PostProcessing/python/Lumberjack/_postprocessor.py
@@ -9,6 +9,7 @@ import time
 
 from array import array
 from enum import Enum
+from collections import OrderedDict
 
 
 __all__ = ["PostProcessor", "Timer"]
@@ -259,11 +260,13 @@ class PostProcessor(object):
 
         # write out ROOT objects
         if isinstance(object_or_dict, dict):
+            # sort dict, so that the output inside the root file is sorted
+            _od = OrderedDict(sorted(object_or_dict.iteritems()))
             # create the output directory inside the ROOT file (if it does not exist)
             if not output_file.GetDirectory(output_path):
                 output_file.mkdir(output_path)
             # recurse through all the subdictionaries
-            for _subkey, _subobject_or_dict in object_or_dict.iteritems():
+            for _subkey, _subobject_or_dict in _od.iteritems():
                 _subdir = "{}/{}".format(output_path, _subkey)
                 PostProcessor._write_output_recursively(_subobject_or_dict, output_file, _subdir)
         else:

--- a/PostProcessing/python/Palisade/Processors/_plot.py
+++ b/PostProcessing/python/Palisade/Processors/_plot.py
@@ -528,15 +528,20 @@ class PlotProcessor(_ProcessorBase):
             return handles, labels
 
         # temporarily cast to array to use numpy indexing
-        _hs, _ls = np.asarray(handles), np.asarray(labels)
+        # note: explicitly use object arrays to prevent
+        # creation of 2d arrays when handle type is iterable
+        _hs = np.empty(len(handles), dtype=object)
+        _ls = np.empty(len(labels), dtype=object)
+        _hs[:] = handles
+        _ls[:] = labels
+
+        # use criterion as a bool index to operate only
+        # on handles that are part of a stack
         _criterion = np.vectorize(lambda label: label in stack_labels)
 
         # reverse sublist selected by criterion
         _ls[_criterion(_ls)] = _ls[_criterion(_ls)][::-1]
         _hs[_criterion(_ls)] = _hs[_criterion(_ls)][::-1]
-
-        # cast back to artist container (artist container)
-        _hs = map(tuple, _hs)
 
         # return as lists
         return list(_hs), list(_ls)


### PR DESCRIPTION
Sort the output before writing it to a root file. This makes finding the correct histograms to view inside a TBrowser way more convenient.